### PR TITLE
ユーザー自身のイベント作成＆保存機能実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,3 +3,4 @@
 @import "modules/index";
 @import "modules/simple_calendar";
 @import "modules/flash";
+@import "modules/new";

--- a/app/assets/stylesheets/modules/index.scss
+++ b/app/assets/stylesheets/modules/index.scss
@@ -62,19 +62,36 @@ ul {
   width: 80px;
 }
 
-.TvTitle {
+.TvSchedule {
   margin-bottom: 5px;
   border: 1px solid deeppink;
+  
+  .start_time {
+    background-color: #FFDDFF;
+  }
+  
+  .channel {
+    background-color: #FFFFCC;
+  }
+  
+  .title {
+    background-color: #BBFFFF;
+  }
 }
 
-.start_time {
-  background-color: #FFDDFF;
-}
-
-.channel {
-  background-color: #FFFFCC;
-}
-
-.title {
-  background-color: #BBFFFF;
+.UserEvent {
+  margin-bottom: 5px;
+  border: 1px solid deeppink;
+  
+  .start_time {
+    background-color: darkseagreen;
+  }
+  
+  .channel {
+    background-color: #FFFFCC;
+  }
+  
+  .title {
+    background-color: #BBFFFF;
+  }
 }

--- a/app/assets/stylesheets/modules/new.scss
+++ b/app/assets/stylesheets/modules/new.scss
@@ -1,0 +1,34 @@
+.EventForm {
+  width: 100%;
+  height: calc(100vh - 100px);
+  background-color: darkcyan;
+  text-align: center;
+  padding: 10px 0;
+}
+
+.EventField {
+  padding-bottom: 20px;
+  font-size: 20px;
+  color: black;
+}
+
+label {
+  color: darkorange;
+}
+
+#title {
+  width: 40%;
+}
+
+select {
+  border: 1px solid black;
+  background-color: blanchedalmond;
+  color: black;
+}
+
+#tv_schedule_channel {
+  width: 40%;
+  height: 100px;
+  background-color: blanchedalmond;
+  border: 1px solid black;
+}

--- a/app/controllers/tv_schedules_controller.rb
+++ b/app/controllers/tv_schedules_controller.rb
@@ -4,9 +4,15 @@ class TvSchedulesController < ApplicationController
   require 'chronic'
 
   def index
+    @events = TvSchedule.all
   end
 
   def search
+    @tvs = []
+    events = TvSchedule.all
+    events.each do |event|
+      @tvs << event
+    end
     word = tv_schedule_params[:keyword]
     if word.present?
       agent = Mechanize.new
@@ -21,13 +27,14 @@ class TvSchedulesController < ApplicationController
         DateTimeEdit(date_docs)
         TitleEdit(title_docs)
         ChannelEdit(channel_docs)
-        @tvs = []
+        # @tvs = []
         @dates.zip(@titles, @channels) do |date, title, channel|
           @tv = TvSchedule.new
           @tv.start_time = date
           @tv.title = title
           @tv.channel = channel
           @tvs << @tv
+          # binding.pry
         end
       else
         flash.now[:alert] = '検索結果はありませんでした。'

--- a/app/controllers/tv_schedules_controller.rb
+++ b/app/controllers/tv_schedules_controller.rb
@@ -7,6 +7,20 @@ class TvSchedulesController < ApplicationController
     @events = TvSchedule.all
   end
 
+  def new
+    @tv_schedule = TvSchedule.new
+  end
+
+  def create
+    @tv_schedule = TvSchedule.new(event_params)
+    if @tv_schedule.save
+      redirect_to root_path
+    else
+      flash.now[:alert] = '保存が出来ませんでした。'
+      render :new
+    end
+  end
+
   def search
     @tvs = []
     events = TvSchedule.all
@@ -27,15 +41,14 @@ class TvSchedulesController < ApplicationController
         DateTimeEdit(date_docs)
         TitleEdit(title_docs)
         ChannelEdit(channel_docs)
-        # @tvs = []
         @dates.zip(@titles, @channels) do |date, title, channel|
           @tv = TvSchedule.new
           @tv.start_time = date
           @tv.title = title
           @tv.channel = channel
           @tvs << @tv
-          # binding.pry
         end
+        @tvs.sort_by { |a| a[:start_time] }
       else
         flash.now[:alert] = '検索結果はありませんでした。'
         render :index
@@ -78,5 +91,9 @@ class TvSchedulesController < ApplicationController
 
   def tv_schedule_params
     params.permit(:keyword)
+  end
+
+  def event_params
+    params.require(:tv_schedule).permit(:title, :start_time, :channel).merge(user_id: current_user.id)
   end
 end

--- a/app/models/tv_schedule.rb
+++ b/app/models/tv_schedule.rb
@@ -1,2 +1,9 @@
 class TvSchedule < ApplicationRecord
+  belongs_to :user
+
+  with_options presence: true do
+    validates :title
+    validates :start_time
+    validates :channel
+  end
 end

--- a/app/models/tv_schedule.rb
+++ b/app/models/tv_schedule.rb
@@ -1,3 +1,2 @@
 class TvSchedule < ApplicationRecord
-  validates :keyword, presence: { message: 'は１文字以上入力してください。' }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  has_many :tv_schedules
+
   with_options presence: true do
     validates :name
     validates :email

--- a/app/views/tv_schedules/index.html.erb
+++ b/app/views/tv_schedules/index.html.erb
@@ -12,16 +12,16 @@
         <%= form.submit "検索", class: "SearchBtn" %>
         <% end %>
     </div>
-      <%= week_calendar number_of_weeks: 1 do |date, tvs| %>
+      <%= week_calendar number_of_weeks: 1, events: @events do |date, events| %>
       
         <%= date.day %>
 
-        <% tvs.each do |tv| %>
-          <div class="TvTitle">
+        <% events.each do |event| %>
+          <div class="UserEvent">
             <ul>
-              <li class="start_time"><%= tv.start_time.to_s(:datetime) %></li>
-              <li class="channel"><%= tv.channel %></li>
-              <li class="title"><%= tv.title %></li>
+              <li class="start_time"><%= event.start_time.to_s(:datetime) %></li>
+              <li class="channel"><%= event.channel %></li>
+              <li class="title"><%= event.title %></li>
             </ul>
           </div>
         <% end %>

--- a/app/views/tv_schedules/index.html.erb
+++ b/app/views/tv_schedules/index.html.erb
@@ -4,6 +4,7 @@
       <div class="UserInfo">
         <div class="UserName"><%= current_user.name %></div>
         <ul class="link_box">
+          <li><%= link_to 'イベント作成', new_tv_schedule_path, class: "CreateEvent" %></li>
           <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: "logout" %></li>
         </ul>
       </div>

--- a/app/views/tv_schedules/new.html.erb
+++ b/app/views/tv_schedules/new.html.erb
@@ -1,0 +1,35 @@
+<div class="wrapper">
+  <div class="header">
+    <div class="UserInfo">
+      <div class="UserName"><%= current_user.name %></div>
+      <ul>
+        <li><%= link_to '戻る', root_path, class: "CreateEvent" %></li>
+        
+      </ul>
+    </div>
+  </div>
+    <div class="EventForm">
+      
+        <%= form_with url: tv_schedules_path, model: @tv_schedule, method: :post, local: true do |form| %>
+          <div class="EventField title">
+            <%= form.label :title %><br />
+            <%= form.text_field :title %>
+          </div>
+
+          <div class="EventField">
+            <%= form.label :start_time %><br />
+            <%= form.datetime_select :start_time, class: "StartTime" %>
+          </div>
+
+          <div class="EventField">
+            <%= form.label :channel %><br />
+            <%= form.text_area :channel %>
+          </div>
+
+          <div class="EventSubmit">
+            <%= form.submit "save" %>
+          </div>
+
+        <% end %>
+    </div>
+</div>

--- a/app/views/tv_schedules/search.html.erb
+++ b/app/views/tv_schedules/search.html.erb
@@ -5,6 +5,7 @@
         <div class="UserName"><%= current_user.name %></div>
         <ul class="link_box">
           <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: "logout" %></li>
+          <li><%= link_to '戻る', root_path, method: :get, class: "logout" %></li>
         </ul>
       </div>
         <%= form_with(url: search_tv_schedules_path, local: true, method: :get, class: "SearchForm") do |form| %>
@@ -13,17 +14,26 @@
         <% end %>
     </div>
       <%= week_calendar number_of_weeks: 1, events: @tvs do |date, tvs| %>
-      
         <%= date.day %>
 
         <% tvs.each do |tv| %>
-          <div class="TvTitle">
-            <ul>
-              <li class="start_time"><%= tv.start_time.to_s(:datetime) %></li>
-              <li class="channel"><%= tv.channel %></li>
-              <li class="title"><%= tv.title %></li>
-            </ul>
-          </div>
+          <% if tv.user_id.present? %>
+            <div class="UserEvent">
+              <ul>
+                <li class="start_time"><%= tv.start_time.to_s(:datetime) %></li>
+                <li class="channel"><%= tv.channel %></li>
+                <li class="title"><%= tv.title %></li>
+              </ul>
+            </div>
+          <% else %>
+            <div class="TvSchedule">
+              <ul>
+                <li class="start_time"><%= tv.start_time.to_s(:datetime) %></li>
+                <li class="channel"><%= tv.channel %></li>
+                <li class="title"><%= tv.title %></li>
+              </ul>
+            </div>
+          <% end %>
         <% end %>
       <% end %>
   <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'tv_schedules#index'
-  resources :tv_schedules, only: :index do
+  resources :tv_schedules, only: [:new, :create] do
     collection do
       get 'search'
     end


### PR DESCRIPTION
# What
- tv_schedules_controllerのindexにアクション定義、searchにuserが保存したイベントも一緒に表示出来るように追記
- index画面にuserの登録済イベントが表示されるように修正
- search画面にuserのイベントかtvスケジュールかをで表示を分岐
- 自分のイベントを作成するnew画面（html&scss）作成
- tv_schedules_controllerにnew/createのアクション設定、searchに開始時間でソート（降順）を追記
- tv_schedulesのnew/createルーティング設定
- tv_schedule.rbにアソシエーションとバリデーション設定
- user.rbにアソシエーション設定

# Why
ユーザー自身の予定と番組放送時間が一つの画面(カレンダー画面)で、確認出来き利便性が向上の為、追加実装